### PR TITLE
Add LLM options to settings and options page

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -80,6 +80,12 @@ w: https://www.wikipedia.org/w/index.php?title=Special:Search&search=%s Wikipedi
   waitForEnterForFilteredHints: true,
   helpDialog_showAdvancedCommands: false,
   ignoreKeyboardLayout: false,
+  llmEnabled: false,
+  llmProvider: "openai",
+  llmModel: "gpt-4o-mini",
+  llmEndpoint: "https://api.openai.com/v1/chat/completions",
+  llmTemperature: 0.7,
+  llmMaxTokens: 1024,
 };
 
 /*

--- a/pages/options.html
+++ b/pages/options.html
@@ -238,6 +238,61 @@ b: http://b.com/?q=%s description
           These styles are used in addition to and take precedence over Vimium's default styles.
         </div>
 
+        <header>LLM Options</header>
+
+        <h2></h2>
+        <label class="boolean-label">
+          <input name="llmEnabled" type="checkbox" />
+          Enable LLM features
+        </label>
+        <div class="example">
+          Turn on LLM-powered features that use the configured provider.
+        </div>
+
+        <h2>Provider</h2>
+        <select name="llmProvider">
+          <option value="openai">OpenAI-compatible</option>
+          <option value="anthropic">Anthropic</option>
+          <option value="ollama">Ollama</option>
+          <option value="openrouter">OpenRouter</option>
+          <option value="custom">Custom</option>
+        </select>
+        <div class="example">
+          Choose the API flavor. Use "OpenAI-compatible" for most OpenAI-style endpoints.
+        </div>
+
+        <h2>Model</h2>
+        <input name="llmModel" type="text" />
+        <div class="example">
+          Examples: <code>gpt-4o-mini</code>, <code>claude-3-5-sonnet-20241022</code>,
+          <code>llama3.1:8b</code>.
+        </div>
+
+        <h2>Endpoint</h2>
+        <input name="llmEndpoint" type="text" />
+        <div class="example">
+          Example: <code>https://api.openai.com/v1/chat/completions</code>. For Ollama, try
+          <code>http://localhost:11434/v1/chat/completions</code>.
+        </div>
+
+        <h2>API Key</h2>
+        <input name="llmApiKey" type="password" autocomplete="off" />
+        <div class="example">
+          Stored locally (not synced). Leave blank if your endpoint does not require a key.
+        </div>
+
+        <h2>Temperature</h2>
+        <input name="llmTemperature" type="number" step="0.1" min="0" />
+        <div class="example">
+          Lower values are more deterministic; higher values are more creative.
+        </div>
+
+        <h2>Max tokens</h2>
+        <input name="llmMaxTokens" type="number" min="1" />
+        <div class="example">
+          Upper limit for response length per request.
+        </div>
+
         <header>Backup and Restore</header>
 
         <h2>Backup</h2>

--- a/pages/options.js
+++ b/pages/options.js
@@ -4,6 +4,8 @@ import { allCommands } from "../background_scripts/all_commands.js";
 import { Commands, KeyMappingsParser } from "../background_scripts/commands.js";
 import * as userSearchEngines from "../background_scripts/user_search_engines.js";
 
+const llmApiKeyStorageKey = "llmApiKey";
+
 const options = {
   filterLinkHints: "boolean",
   grabBackFocus: "boolean",
@@ -11,6 +13,12 @@ const options = {
   hideUpdateNotifications: "boolean",
   ignoreKeyboardLayout: "boolean",
   keyMappings: "string",
+  llmEnabled: "boolean",
+  llmEndpoint: "string",
+  llmMaxTokens: "number",
+  llmModel: "string",
+  llmProvider: "string",
+  llmTemperature: "number",
   linkHintCharacters: "string",
   linkHintNumbers: "string",
   newTabCustomUrl: "string",
@@ -98,6 +106,7 @@ const OptionsPage = {
 
     const settings = Settings.getSettings();
     this.setFormFromSettings(settings);
+    await this.loadLlmApiKey();
   },
 
   getOptionEl(optionName) {
@@ -272,6 +281,7 @@ const OptionsPage = {
       return;
     }
 
+    await this.saveLlmApiKey();
     await Settings.setSettings(this.getSettingsFromForm());
     const el = document.querySelector("#save");
     el.disabled = true;
@@ -351,6 +361,22 @@ const OptionsPage = {
         alert("Settings have been restored from the backup.");
       };
     }
+  },
+
+  async loadLlmApiKey() {
+    const result = await chrome.storage.local.get({ [llmApiKeyStorageKey]: "" });
+    const apiKeyInput = this.getOptionEl("llmApiKey");
+    if (apiKeyInput) {
+      apiKeyInput.value = result[llmApiKeyStorageKey] ?? "";
+    }
+  },
+
+  async saveLlmApiKey() {
+    const apiKeyInput = this.getOptionEl("llmApiKey");
+    if (!apiKeyInput) {
+      return;
+    }
+    await chrome.storage.local.set({ [llmApiKeyStorageKey]: apiKeyInput.value.trim() });
   },
 };
 


### PR DESCRIPTION
### Motivation

- Provide configurable LLM settings so LLM-powered features can be enabled and tuned from the Options UI.
- Keep the sensitive API key out of synced settings by storing it locally instead of in `Settings`.
- Surface provider/model/endpoint/temperature/token controls with example guidance so users can configure different backends.
- Place the LLM block after Advanced Options so it is discoverable but separated from core navigation settings.

### Description

- Added default LLM fields to `defaultOptions` in `lib/settings.js`: `llmEnabled`, `llmProvider`, `llmModel`, `llmEndpoint`, `llmTemperature`, and `llmMaxTokens`.
- Added an LLM configuration section to `pages/options.html` with inputs for `llmProvider`, `llmModel`, `llmEndpoint`, `llmApiKey` (password), `llmTemperature`, and `llmMaxTokens`, including explanatory examples.
- Wired the new sync-able LLM fields into the `options` mapping in `pages/options.js` so `setFormFromSettings` and `getSettingsFromForm` will read/write them, and added `llmApiKey` handling via separate `chrome.storage.local` reads/writes using `loadLlmApiKey` and `saveLlmApiKey`.
- Ensured `loadLlmApiKey` is called during `OptionsPage.init()` and `saveLlmApiKey` is called during `saveOptions()` so the API key is persisted locally while remaining out of synced settings.

### Testing

- Loaded the options page via a local HTTP server and used Playwright to open `pages/options.html` and capture a screenshot showing the LLM section, which rendered successfully.
- No unit tests were modified for this UI-only change and no automated test failures were observed during the manual UI verification.
- Basic manual validation: the options page saved via the UI flow and `chrome.storage.local` API key read/write functions were invoked during save/init (as exercised by the Playwright load/save flow).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dd9a27614832993b7210a23e7f876)