### PR TITLE
Add LLM commands and wire NormalMode handlers to LLMController

### DIFF
--- a/background_scripts/all_commands.js
+++ b/background_scripts/all_commands.js
@@ -596,6 +596,42 @@ const allCommands = [
   },
 
   //
+  // LLM
+  //
+
+  {
+    name: "enterLLMMode",
+    desc: "Enter LLM mode",
+    group: "llm",
+    noRepeat: true,
+    topFrame: true,
+  },
+
+  {
+    name: "exitLLMMode",
+    desc: "Exit LLM mode",
+    group: "llm",
+    noRepeat: true,
+    topFrame: true,
+  },
+
+  {
+    name: "toggleLLMMode",
+    desc: "Toggle LLM mode",
+    group: "llm",
+    noRepeat: true,
+    topFrame: true,
+  },
+
+  {
+    name: "llmScreenshot",
+    desc: "Capture a screenshot for LLM",
+    group: "llm",
+    noRepeat: true,
+    topFrame: true,
+  },
+
+  //
   // Misc
   //
 

--- a/content_scripts/mode_normal.js
+++ b/content_scripts/mode_normal.js
@@ -245,6 +245,18 @@ const NormalModeCommands = {
   showHelp(sourceFrameId) {
     return HelpDialog.toggle({ sourceFrameId });
   },
+  enterLLMMode() {
+    return LLMController.show();
+  },
+  exitLLMMode() {
+    return LLMController.hide();
+  },
+  toggleLLMMode() {
+    return LLMController.toggle();
+  },
+  llmScreenshot() {
+    return LLMController.screenshot();
+  },
 
   passNextKey(count, options) {
     // TODO(philc): OK to remove return statement?


### PR DESCRIPTION
### Motivation

- Introduce keyboard commands to control an LLM UI (enter/exit/toggle/screenshot) so users can invoke LLM features via Vimium commands.
- Ensure LLM commands behave consistently as top-frame-only actions to avoid UI-component/frame focus issues.

### Description

- Add new command entries grouped under `llm` in `background_scripts/all_commands.js` for `enterLLMMode`, `exitLLMMode`, `toggleLLMMode`, and `llmScreenshot` with `noRepeat: true` and `topFrame: true`.
- Wire Normal mode command handlers in `content_scripts/mode_normal.js` to call `LLMController.show()`, `LLMController.hide()`, `LLMController.toggle()`, and `LLMController.screenshot()` respectively.
- Commands marked as `topFrame` will use the existing `runInTopFrame` mechanism via the normal command dispatch path.
- Changed files: `background_scripts/all_commands.js` and `content_scripts/mode_normal.js`.

### Testing

- No automated tests were executed for this change.
- Basic static verification performed: files were added/updated and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dd9aea86483298e4c398d031a67c1)