### PR TITLE
Add LLM screenshot capture command and UI

### DIFF
--- a/background_scripts/all_commands.js
+++ b/background_scripts/all_commands.js
@@ -614,6 +614,13 @@ const allCommands = [
     noRepeat: true,
     topFrame: true,
   },
+  {
+    name: "llmCaptureScreenshot",
+    desc: "Capture a screenshot for LLM",
+    group: "misc",
+    noRepeat: true,
+    topFrame: true,
+  },
 ];
 
 export { allCommands };

--- a/background_scripts/main.js
+++ b/background_scripts/main.js
@@ -739,6 +739,12 @@ const sendRequestHandlers = {
     const completer = completers[request.completerName];
     completer.cancel();
   },
+
+  async captureVisibleTab(_request, sender) {
+    return await chrome.tabs.captureVisibleTab(sender.tab.windowId, {
+      format: "png",
+    });
+  },
 };
 
 Utils.addChromeRuntimeOnMessageListener(

--- a/content_scripts/llm_mode.js
+++ b/content_scripts/llm_mode.js
@@ -1,0 +1,19 @@
+const LLMMode = {
+  llmUI: null,
+
+  init() {
+    if (!this.llmUI) {
+      this.llmUI = new UIComponent();
+      this.llmUI.load("pages/llm_frame.html", "vimium-llm-frame");
+    }
+  },
+
+  async requestScreenshot() {
+    this.init();
+    const dataUrl = await chrome.runtime.sendMessage({ handler: "captureVisibleTab" });
+    if (!dataUrl) return;
+    this.llmUI.show({ name: "showScreenshot", dataUrl }, { focus: false });
+  },
+};
+
+globalThis.LLMMode = LLMMode;

--- a/content_scripts/mode_normal.js
+++ b/content_scripts/mode_normal.js
@@ -245,6 +245,9 @@ const NormalModeCommands = {
   showHelp(sourceFrameId) {
     return HelpDialog.toggle({ sourceFrameId });
   },
+  llmCaptureScreenshot() {
+    return LLMMode.requestScreenshot();
+  },
 
   passNextKey(count, options) {
     // TODO(philc): OK to remove return statement?

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -218,6 +218,20 @@ iframe.vomnibar-frame {
   z-index: 2147483647;
 }
 
+iframe.vimium-llm-frame {
+  background-color: transparent;
+  padding: 0px;
+  overflow: hidden;
+  display: block;
+  position: fixed;
+  width: 340px;
+  height: 420px;
+  bottom: 20px;
+  left: 20px;
+  border: none;
+  z-index: 2147483647;
+}
+
 div.vimium-flash {
   box-shadow: 0px 0px 4px 2px #4183c4;
   padding: 1px;

--- a/manifest.json
+++ b/manifest.json
@@ -56,6 +56,7 @@
         "content_scripts/mode_key_handler.js",
         "content_scripts/mode_visual.js",
         "content_scripts/hud.js",
+        "content_scripts/llm_mode.js",
         "content_scripts/mode_normal.js",
         "content_scripts/vimium_frontend.js"
       ],
@@ -97,6 +98,9 @@
         "pages/help_dialog_page.html",
         "pages/doc_completion_engines.html",
         "pages/command_listing.html",
+        "pages/llm_frame.html",
+        "pages/llm_frame.css",
+        "pages/llm_frame.js",
         "resources/tlds.txt",
         // This allows one to script the reloading of Vimium.
         // This should only be enabled in development.

--- a/pages/llm_frame.css
+++ b/pages/llm_frame.css
@@ -1,0 +1,33 @@
+.llm-container {
+  font-family: system-ui, sans-serif;
+  color: var(--vimium-background-text-color, #111);
+  background: var(--vimium-background-color, #fff);
+  border-radius: 8px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+  padding: 12px;
+  width: 320px;
+}
+
+.llm-title {
+  font-size: 13px;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.llm-screenshot {
+  width: 100%;
+  height: auto;
+  border-radius: 6px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  background: #f2f2f2;
+}
+
+.llm-observation {
+  margin-top: 8px;
+  font-size: 11px;
+  color: var(--vimium-foreground-text-color, #333);
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 160px;
+  overflow: auto;
+}

--- a/pages/llm_frame.html
+++ b/pages/llm_frame.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <link rel="stylesheet" href="./llm_frame.css" />
+  </head>
+  <body class="vimium-reset">
+    <div class="llm-container">
+      <div class="llm-title">Latest LLM Screenshot</div>
+      <img class="llm-screenshot" alt="LLM screenshot preview" />
+      <pre class="llm-observation"></pre>
+    </div>
+    <script type="module" src="./llm_frame.js"></script>
+  </body>
+</html>

--- a/pages/llm_frame.js
+++ b/pages/llm_frame.js
@@ -1,0 +1,23 @@
+import * as UIComponentMessenger from "./ui_component_messenger.js";
+
+const screenshotEl = document.querySelector(".llm-screenshot");
+const observationEl = document.querySelector(".llm-observation");
+
+function updateScreenshot(dataUrl) {
+  if (!dataUrl) return;
+  screenshotEl.src = dataUrl;
+  observationEl.textContent = `observation: ${dataUrl}`;
+}
+
+async function onMessage(event) {
+  const name = event.data?.name;
+  if (name === "showScreenshot") {
+    updateScreenshot(event.data.dataUrl);
+  } else if (name === "hidden") {
+    observationEl.textContent = "";
+    screenshotEl.removeAttribute("src");
+  }
+}
+
+UIComponentMessenger.init();
+UIComponentMessenger.registerHandler(onMessage);


### PR DESCRIPTION
### Motivation
- Provide a way for the LLM integration to capture the current visible tab as an observation and display a preview in the LLM UI frame.
- Allow keyboard-triggered screenshot capture from Normal mode so screenshots can be requested without opening developer tools or external tooling.

### Description
- Added a background request handler `captureVisibleTab` (in `background_scripts/main.js`) that calls `chrome.tabs.captureVisibleTab` and returns a PNG data URL.
- Added a new content script `content_scripts/llm_mode.js` exposing `LLMMode.requestScreenshot()` which sends `{ handler: "captureVisibleTab" }` and shows the result in a `UIComponent` iframe via `llm_frame.html`.
- Added the LLM iframe UI (`pages/llm_frame.html`, `pages/llm_frame.css`, `pages/llm_frame.js`) which receives `showScreenshot` messages via `ui_component_messenger.js` and renders a thumbnail and an `observation` text containing the base64 data URL.
- Registered the new command `llmCaptureScreenshot` in `background_scripts/all_commands.js`, bound it to `NormalModeCommands.llmCaptureScreenshot` in `content_scripts/mode_normal.js`, added iframe CSS in `content_scripts/vimium.css`, and updated `manifest.json` to include new assets.

### Testing
- No automated tests were run for this change (no CI/test commands executed during the rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dd9a69c1883298723a1df80589af7)