### PR TITLE
Enable LLM by default; add API-key capture, screenshot-hide and auto-execute Vimium actions

### DIFF
--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -224,14 +224,20 @@ iframe.vimium-llm-frame {
   overflow: hidden;
   display: block;
   position: fixed;
-  width: 420px;
-  height: 640px;
-  bottom: 90px;
-  right: 20px;
+  width: 360px;
+  height: 100%;
+  top: 0;
+  right: 0;
   border: none;
   z-index: 2147483647;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
-  border-radius: 12px;
+  border-radius: 12px 0 0 12px;
+  transition: opacity 0.15s ease-in-out;
+}
+
+iframe.vimium-llm-frame.vimium-llm-frame--hidden-for-capture {
+  opacity: 0;
+  pointer-events: none;
 }
 
 div.vimium-flash {

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -80,7 +80,7 @@ w: https://www.wikipedia.org/w/index.php?title=Special:Search&search=%s Wikipedi
   waitForEnterForFilteredHints: true,
   helpDialog_showAdvancedCommands: false,
   ignoreKeyboardLayout: false,
-  llmEnabled: false,
+  llmEnabled: true,
   llmIncludeScreenshot: true,
   llmApiBaseUrl: "https://api.openai.com/v1",
   llmApiKey: "",

--- a/pages/llm_frame.css
+++ b/pages/llm_frame.css
@@ -16,7 +16,8 @@ body {
   gap: 12px;
   padding: 14px 16px 16px;
   box-sizing: border-box;
-  height: 100%;
+  height: 100vh;
+  overflow: hidden;
 }
 
 .llm-header {
@@ -87,12 +88,12 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  min-height: 90px;
+  min-height: 120px;
 }
 
 #llm-screenshot {
   width: 100%;
-  max-height: 140px;
+  max-height: 200px;
   object-fit: cover;
   border-radius: 8px;
   display: none;
@@ -104,7 +105,7 @@ body {
 
 .llm-react-panels {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: minmax(0, 1fr);
   gap: 10px;
   flex: 1;
   min-height: 0;
@@ -116,6 +117,12 @@ body {
   gap: 8px;
 }
 
+.llm-chat-hint {
+  margin: 0;
+  font-size: 11px;
+  color: rgba(127, 127, 127, 0.8);
+}
+
 .llm-chat-log {
   background: rgba(127, 127, 127, 0.08);
   border-radius: 10px;
@@ -123,7 +130,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  max-height: 120px;
+  max-height: 160px;
   overflow: auto;
   font-size: 12px;
 }
@@ -175,6 +182,7 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 0;
+  max-height: 160px;
 }
 
 .llm-panel h2,

--- a/pages/llm_frame.html
+++ b/pages/llm_frame.html
@@ -47,9 +47,10 @@
       </section>
       <section class="llm-chat">
         <h2>Chat task</h2>
+        <p class="llm-chat-hint">Missing an API key? Paste it here to save, then resend your task.</p>
         <div id="llm-chat-log" class="llm-chat-log"></div>
         <div class="llm-chat-input">
-          <textarea id="llm-chat-text" placeholder="Describe the task you want Vimium to do..."></textarea>
+          <textarea id="llm-chat-text" placeholder="Describe the task or paste your API key..."></textarea>
           <button id="llm-chat-send" type="button">Send</button>
         </div>
       </section>


### PR DESCRIPTION
### Motivation
- Enable the built-in LLM assistant by default so the overlay is available out-of-the-box.
- Let users supply an LLM API key quickly from the overlay chat so requests can continue without using the options page.
- Prevent the overlay from appearing in captured screenshots used for LLM analysis to avoid leaking the chat UI into the image.
- Automatically apply Vimium key suggestions returned by the model to streamline analysis → action loops.

### Description
- Set `llmEnabled: true` in `lib/settings.js` to enable the LLM feature by default.
- Add overlay hide-for-capture helpers (`setOverlayHiddenForScreenshot`, `withScreenshotHidden`) and a CSS class `vimium-llm-frame--hidden-for-capture` to temporarily hide the LLM iframe during screenshot capture (changes in `content_scripts/vimium_frontend.js` and `content_scripts/vimium.css`).
- Implement API-key capture flow in the overlay: `runChat` and `runAnalysis` will prompt/save a pasted API key into settings when none exists and surface guidance in the chat UI (changes to `content_scripts/vimium_frontend.js` and `pages/llm_frame.html`/`.css`).
- Add key-parsing and dispatching utilities (`parseVimiumKeySequence`, `dispatchVimiumKeySequence`, `maybeAutoExecuteAction`, and `buildKeyEvent`) and invoke `maybeAutoExecuteAction` after successful LLM responses so suggested Vimium key sequences can be auto-dispatched into the page (in `content_scripts/vimium_frontend.js`).
- Restyle the LLM overlay into a right-side sidebar layout and update panel sizes and chat hints (changes in `pages/llm_frame.css` and `pages/llm_frame.html`).

### Testing
- A Playwright-based smoke render was run to load the updated `pages/llm_frame.html` and generate a screenshot artifact (`artifacts/llm_frame.png`), which completed successfully.
- No unit or CI test suites were executed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e24df30548329bbc5b89d81a06ce5)