### PR TITLE
Improve LLM overlay capture behavior and auto-action execution

### DIFF
--- a/background_scripts/main.js
+++ b/background_scripts/main.js
@@ -218,6 +218,10 @@ function buildLLMPrompt({ prompt, pageContext }) {
   if (prompt) {
     lines.push(`User prompt: ${prompt}`);
   }
+  lines.push(
+    "Use Vimium key sequences for actions (e.g. \"f\", \"gg\", \"<enter>\"). " +
+      "Avoid CSS selectors; rely on Vimium link hints to select elements.",
+  );
   lines.push("Respond with a JSON object containing thought, action, observation, nextAction.");
   return lines.join("\n");
 }

--- a/background_scripts/main.js
+++ b/background_scripts/main.js
@@ -272,11 +272,13 @@ async function runLLMRequest(request, sender) {
   const includeScreenshot = request.includeScreenshot && Settings.get("llmIncludeScreenshot");
 
   let screenshot = "";
+  let captureError = "";
   if (includeScreenshot) {
     try {
       screenshot = await captureVisibleTab(sender);
     } catch (error) {
-      return { error: `Failed to capture screenshot: ${error?.message || error}` };
+      captureError = `Failed to capture screenshot: ${error?.message || error}`;
+      screenshot = "";
     }
   }
 
@@ -326,6 +328,7 @@ async function runLLMRequest(request, sender) {
     result: parsed || {},
     rawResponse: content,
     screenshot,
+    captureError,
   };
 }
 

--- a/background_scripts/main.js
+++ b/background_scripts/main.js
@@ -220,7 +220,8 @@ function buildLLMPrompt({ prompt, pageContext }) {
   }
   lines.push(
     "Use Vimium key sequences for actions (e.g. \"f\", \"gg\", \"<enter>\"). " +
-      "Avoid CSS selectors; rely on Vimium link hints to select elements.",
+      "Avoid CSS selectors; rely on Vimium link hints to select elements. " +
+      "If text entry and submission are needed, use a separate enter action.",
   );
   lines.push("Respond with a JSON object containing thought, action, observation, nextAction.");
   return lines.join("\n");

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -236,8 +236,9 @@ iframe.vimium-llm-frame {
 }
 
 iframe.vimium-llm-frame.vimium-llm-frame--hidden-for-capture {
-  opacity: 0;
+  opacity: 1;
   pointer-events: none;
+  box-shadow: none;
 }
 
 div.vimium-flash {

--- a/content_scripts/vimium_frontend.js
+++ b/content_scripts/vimium_frontend.js
@@ -745,12 +745,11 @@ const LLMFrame = {
       target.dispatchEvent(new Event("change", { bubbles: true }));
     }
     if (hasEnter) {
-      const enterEvent = this.buildKeyEvent("Enter");
-      enterEvent.target = target;
-      target.dispatchEvent(new KeyboardEvent("keydown", enterEvent));
-      target.dispatchEvent(new KeyboardEvent("keyup", enterEvent));
+      this.dispatchVimiumKeySequence("<enter>");
     }
-    return "Auto-typed text into the active input.";
+    return hasEnter
+      ? "Auto-typed text into the active input and pressed Enter."
+      : "Auto-typed text into the active input.";
   },
 
   normalizeSpecialKey(key) {

--- a/content_scripts/vimium_frontend.js
+++ b/content_scripts/vimium_frontend.js
@@ -609,6 +609,8 @@ const LLMFrame = {
       metaKey: Boolean(modifiers.metaKey),
       shiftKey: Boolean(modifiers.shiftKey),
       isTrusted: true,
+      preventDefault() {},
+      stopImmediatePropagation() {},
     };
   },
 

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -93,6 +93,7 @@ w: https://www.wikipedia.org/w/index.php?title=Special:Search&search=%s Wikipedi
     `Always respond with a JSON object using the keys: thought, action, observation, nextAction.\n` +
     `Use Vimium key sequences for action/nextAction (e.g. "f", "gg", "<enter>").\n` +
     `Avoid CSS selectors; rely on Vimium link hints and commands to choose elements.\n` +
+    `When entering text and submitting, prefer separate steps (type text, then <enter>).\n` +
     `Keep "thought" concise and do not include extra keys.`,
   llmUserPrompt: "Analyze the current page and suggest the next best Vimium action.",
 };

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -90,6 +90,8 @@ w: https://www.wikipedia.org/w/index.php?title=Special:Search&search=%s Wikipedi
   llmSystemPrompt: `You are a browser assistant following the ReAct framework (Reasoning + Acting).\n` +
     `Use the structure from "ReAct: Synergizing Reasoning and Acting in Language Models".\n` +
     `Always respond with a JSON object using the keys: thought, action, observation, nextAction.\n` +
+    `Use Vimium key sequences for action/nextAction (e.g. "f", "gg", "<enter>").\n` +
+    `Avoid CSS selectors; rely on Vimium link hints and commands to choose elements.\n` +
     `Keep "thought" concise and do not include extra keys.`,
   llmUserPrompt: "Analyze the current page and suggest the next best Vimium action.",
 };

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -87,6 +87,7 @@ w: https://www.wikipedia.org/w/index.php?title=Special:Search&search=%s Wikipedi
   llmModel: "gpt-4o-mini",
   llmTemperature: 0.2,
   llmMaxTokens: 512,
+  llmAutoRunMaxSteps: 20,
   llmSystemPrompt: `You are a browser assistant following the ReAct framework (Reasoning + Acting).\n` +
     `Use the structure from "ReAct: Synergizing Reasoning and Acting in Language Models".\n` +
     `Always respond with a JSON object using the keys: thought, action, observation, nextAction.\n` +

--- a/pages/llm_frame.css
+++ b/pages/llm_frame.css
@@ -10,6 +10,10 @@ body {
   color: var(--vimium-background-text-color);
 }
 
+body.llm-capture-mode {
+  background: transparent;
+}
+
 #llm-root {
   display: flex;
   flex-direction: column;
@@ -18,6 +22,32 @@ body {
   box-sizing: border-box;
   height: 100vh;
   overflow: hidden;
+}
+
+body.llm-capture-mode #llm-root {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.llm-capture-indicator {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  width: 44px;
+  height: 44px;
+  border-radius: 999px;
+  background: rgba(32, 32, 32, 0.85);
+  color: #ffffff;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  font-size: 22px;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.4);
+  pointer-events: none;
+}
+
+body.llm-capture-mode .llm-capture-indicator {
+  display: flex;
 }
 
 .llm-header {

--- a/pages/llm_frame.css
+++ b/pages/llm_frame.css
@@ -33,17 +33,51 @@ body.llm-capture-mode #llm-root {
   position: fixed;
   right: 16px;
   bottom: 16px;
-  width: 44px;
-  height: 44px;
-  border-radius: 999px;
+  min-width: 44px;
+  min-height: 44px;
+  border-radius: 16px;
   background: rgba(32, 32, 32, 0.85);
   color: #ffffff;
   display: none;
   align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
   justify-content: center;
-  font-size: 22px;
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.4);
   pointer-events: none;
+}
+
+.llm-capture-icon {
+  font-size: 22px;
+  line-height: 1;
+}
+
+.llm-capture-steps {
+  display: grid;
+  gap: 4px;
+  font-size: 11px;
+}
+
+.llm-capture-step {
+  display: grid;
+  grid-template-columns: 32px minmax(0, 1fr);
+  gap: 6px;
+  align-items: center;
+}
+
+.llm-capture-label {
+  color: rgba(255, 255, 255, 0.7);
+  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.06em;
+}
+
+.llm-capture-value {
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 140px;
 }
 
 body.llm-capture-mode .llm-capture-indicator {

--- a/pages/llm_frame.html
+++ b/pages/llm_frame.html
@@ -59,6 +59,18 @@
         <pre id="llm-json"></pre>
       </section>
     </div>
-    <div id="llm-capture-indicator" class="llm-capture-indicator" aria-hidden="true">💬</div>
+    <div id="llm-capture-indicator" class="llm-capture-indicator" aria-hidden="true">
+      <div class="llm-capture-icon">💬</div>
+      <div class="llm-capture-steps">
+        <div class="llm-capture-step">
+          <span class="llm-capture-label">Now</span>
+          <span id="llm-capture-action" class="llm-capture-value">-</span>
+        </div>
+        <div class="llm-capture-step">
+          <span class="llm-capture-label">Next</span>
+          <span id="llm-capture-next" class="llm-capture-value">-</span>
+        </div>
+      </div>
+    </div>
   </body>
 </html>

--- a/pages/llm_frame.html
+++ b/pages/llm_frame.html
@@ -59,5 +59,6 @@
         <pre id="llm-json"></pre>
       </section>
     </div>
+    <div id="llm-capture-indicator" class="llm-capture-indicator" aria-hidden="true">💬</div>
   </body>
 </html>

--- a/pages/llm_frame.js
+++ b/pages/llm_frame.js
@@ -57,6 +57,10 @@ function renderSnapshot(snapshot) {
   setText("llm-json", JSON.stringify(jsonSnapshot, null, 2));
 }
 
+function setCaptureMode(enabled) {
+  document.body.classList.toggle("llm-capture-mode", Boolean(enabled));
+}
+
 function renderChatMessages(messages) {
   const container = document.getElementById("llm-chat-log");
   if (!container) return;
@@ -91,6 +95,7 @@ function handleMessage({ data }) {
   const handlers = {
     llmSnapshot: ({ snapshot }) => renderSnapshot(snapshot),
     llmSetStatus: ({ status }) => renderSnapshot({ status }),
+    llmCaptureMode: ({ enabled }) => setCaptureMode(enabled),
   };
   const handler = handlers[data.name];
   if (handler) {

--- a/pages/llm_frame.js
+++ b/pages/llm_frame.js
@@ -39,6 +39,8 @@ function renderSnapshot(snapshot) {
   setText("llm-action", normalized.action);
   setText("llm-observation", normalized.observation);
   setText("llm-next-action", normalized.nextAction);
+  setText("llm-capture-action", normalized.action || "-");
+  setText("llm-capture-next", normalized.nextAction || "-");
   renderChatMessages(normalized.chatMessages);
   const screenshot = document.getElementById("llm-screenshot");
   if (screenshot) {


### PR DESCRIPTION
### Motivation
- Prevent the LLM overlay from disappearing entirely while a screenshot is captured and instead show a compact indicator to communicate capture is in progress.
- Make automatic action execution more robust by supporting structured LLM outputs (`type`, `vim_key`/`keyPress`) and typing into editable fields when appropriate.
- Encourage the LLM to emit Vimium-friendly key sequences rather than CSS selectors so actions can be performed using Vimium link hints and commands.

### Description
- Keep the LLM iframe visually present during capture by changing the hidden-for-capture CSS behavior and adding a compact capture indicator in `pages/llm_frame.html`/`pages/llm_frame.css`.`
- Add `llmCaptureMode` messaging and `setCaptureMode` in `pages/llm_frame.js` to toggle a `llm-capture-mode` class and show the indicator when screenshots are taken.`
- Extend `content_scripts/vimium_frontend.js` to: normalize special keys, apply `type` actions by focusing and inserting text into editable elements, and handle structured `action`/`nextAction` values (strings or objects) to auto-execute Vimium key sequences and annotate the snapshot observation.`
- Update prompts in `background_scripts/main.js` and default `llmSystemPrompt` in `lib/settings.js` to instruct the LLM to prefer Vimium key sequences (e.g. `f`, `gg`, `<enter>`) and avoid relying on CSS selectors.`

### Testing
- Performed a visual smoke test using Playwright to load `pages/llm_frame.html` and capture a screenshot, which succeeded and produced `artifacts/llm-frame.png`.
- No unit test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e64d5d7608329bf3e0b081a23c6ec)